### PR TITLE
Remove plt.show() calls

### DIFF
--- a/distfit/distfit.py
+++ b/distfit/distfit.py
@@ -444,7 +444,6 @@ class distfit():
             if ylim is not None:
                 plt.ylim(ymin=ylim[0], ymax=ylim[1])
 
-            plt.show()
             return(fig, ax)
         else:
             print('[distfit] This function works only in case of method is "parametric"')
@@ -705,7 +704,6 @@ def _plot_quantile(self, title='', figsize=(15, 8), xlim=None, ylim=None, verbos
     ax.set_ylabel('Frequency')
     ax.set_title(title)
     ax.legend()
-    plt.show()
 
     return fig, ax
 
@@ -787,7 +785,6 @@ def _plot_parametric(self, title='', figsize=(10, 8), xlim=None, ylim=None, verb
 
     ax.legend()
     ax.grid(True)
-    plt.show()
 
     if verbose>=4: print("[distfit] Estimated distribution: %s [loc:%f, scale:%f]" %(model['name'], model['params'][-2], model['params'][-1]))
     return (fig, ax)


### PR DESCRIPTION
Thank you for your time spent making this package.

When you call plt.show(), you've rendered the plot and it can no longer be modified by the user, making it pointless to return the figure and axes objects.

For example, try:

```python
fig, ax = dist.plot()
ax.axvline(x=0)
plt.title("Blarg!")
```

Unlike sns plots and dataframe.plot() calls that many are familiar with, the plots of distfit cannot be modified after called. This is surprising to the user (at least it was to me 😀)