### PR TITLE
feat: set log formatter for distfit log only

### DIFF
--- a/distfit/distfit.py
+++ b/distfit/distfit.py
@@ -22,14 +22,12 @@ import colourmap
 import warnings
 warnings.filterwarnings('ignore')
 
-logger = logging.getLogger('')
-for handler in logger.handlers[:]:
-    logger.removeHandler(handler)
+logger = logging.getLogger(__name__)
 console = logging.StreamHandler()
 formatter = logging.Formatter('[distfit] >%(levelname)s> %(message)s')
 console.setFormatter(formatter)
 logger.addHandler(console)
-logger = logging.getLogger()
+logger.propagate = False
 
 
 # %% Class dist


### PR DESCRIPTION
Good morning! 

First of all, thanks for the great repo! :)

Secondly, I've noticed a small bug in how the distfit logger is set up: by default, distfit adds a Formatter to the logging.root logger.
```python
import logging
from distfit import distfit

if __name__ == "__main__":
    logging.basicConfig()
    logging.root.setLevel(level=logging.INFO)

    logging.info("Hello!")

```
``` output
[distfit] >INFO> Hello!
```

By modifying how the distfit logger is instantiated, the problem is solved!

```python
import logging
from distfit import distfit
import numpy as np

if __name__ == "__main__":
    logging.basicConfig()
    logging.root.setLevel(level=logging.INFO)

    logging.info("Hello!")

    X = np.random.normal(0, 2, 1000)
    y = [-8, -6, 0, 1, 2, 3, 4, 5, 6]

    dfit = distfit()
    dfit.fit_transform(X)

```
``` output
INFO:root:Hello!
[distfit] >INFO> fit
[distfit] >INFO> transform
[distfit] >INFO> [norm      ] [0.00 sec] [RSS: 0.00274495] [loc=0.046 scale=2.006]
[distfit] >INFO> [expon     ] [0.0 sec] [RSS: 0.18902] [loc=-6.794 scale=6.840]
[distfit] >INFO> [pareto    ] [0.00 sec] [RSS: 0.18902] [loc=-536870918.794 scale=536870912.000]
[distfit] >INFO> [dweibull  ] [0.01 sec] [RSS: 0.0047617] [loc=0.035 scale=1.724]
[distfit] >INFO> [t         ] [0.15 sec] [RSS: 0.00274505] [loc=0.046 scale=2.006]
[distfit] >INFO> [genextreme] [0.05 sec] [RSS: 0.00308806] [loc=-0.696 scale=1.992]
[distfit] >INFO> [gamma     ] [0.05 sec] [RSS: 0.00268035] [loc=-112.358 scale=0.036]
[distfit] >INFO> [lognorm   ] [0.10 sec] [RSS: 0.00267983] [loc=-166.408 scale=166.442]
[distfit] >INFO> [beta      ] [0.08 sec] [RSS: 0.00268693] [loc=-31.169 scale=73.876]
[distfit] >INFO> [uniform   ] [0.00 sec] [RSS: 0.125316] [loc=-6.794 scale=13.366]
[distfit] >INFO> [loggamma  ] [0.04 sec] [RSS: 0.00284576] [loc=-408.499 scale=60.128]
[distfit] >INFO> Compute confidence intervals [parametric]

Process finished with exit code 0

```
