### PR TITLE
Parallel dist comp

### DIFF
--- a/distfit/distfit.py
+++ b/distfit/distfit.py
@@ -100,8 +100,8 @@ class distfit:
                  random_state: int = None,
                  verbose: [str, int] = 'info',
                  multtest=None,
-                 n_jobs=1,
-                 n_jobs_dist=1,
+                 n_jobs: int = 1,
+                 n_jobs_dist: int = 1,
                  ):
         """Initialize distfit with user-defined parameters.
 
@@ -155,7 +155,10 @@ class distfit:
             Random state.
         n_jobs : int, optional (default: 1)
             Number of cpu cores that are used to compute the bootstrap.
-            Note that the use of multiple cores accacionally causes a RuntimeWarning: invalid value encountered in log. The results can then be unriable. It is better to set n_jobs=1.
+            Note that the use of multiple cores occasionally causes a RuntimeWarning: invalid value encountered in log. The results can then be unriable. It is better to set n_jobs=1.
+            -1: Use all cores
+        n_jobs_dist : int, optional (default: 1)
+            Number of cpu cores that are used to compute distriubtion fitting.
             -1: Use all cores
         verbose : [str, int], default is 'info' or 20
             Set the verbose messages using string or integer values.


### PR DESCRIPTION
The following aims to enhance the performance of the private method `_compute_score_distribution`, mirroring the logic applied in `_bootstrap`.

Now, `distfit` will introduce an additional optional argument, `n_jobs_dist`, enabling users to parallelly fit distribution candidates. This suggestion aims to reduce computational time, particularly beneficial when fitting numerous candidate distributions to data.

The following experiments have been conducted:

## benchmarking process setup

```python
X = np.random.normal(163, 10, 10000)


def run_prog_bootstrap(n_jobs: int, n_jobs_dist: int):
    dfit = distfit(distr='popular', n_boots=100, n_jobs=n_jobs, n_jobs_dist=n_jobs_dist)

    results = dfit.fit_transform(X)

    return results

def run_prog_raw(n_jobs_dist: int):
    dfit = distfit(distr='popular', n_jobs_dist=n_jobs_dist)

    results = dfit.fit_transform(X)

    return results
```

## experiments - `with bootstrap`

### `%timeit run_prog_bootstrap(n_jobs=4, n_jobs_dist=4)`

> result: 2min 12s ± 11.2 s per loop (mean ± std. dev. of 7 runs, 1 loop each)

### `%timeit run_prog_bootstrap(n_jobs=7, n_jobs_dist=1)`

> result: 2min ± 11.6 s per loop (mean ± std. dev. of 7 runs, 1 loop each)

### `%timeit run_prog_bootstrap(n_jobs=1, n_jobs_dist=1)`

> result: 4min 44s ± 25.9 s per loop (mean ± std. dev. of 7 runs, 1 loop each)

## experiments - `without bootstrap`

### `%timeit run_prog_raw(n_jobs_dist=1)`

> result: 2.57 s ± 114 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

### `%timeit run_prog_raw(n_jobs_dist=8)`

> result: 1.63 s ± 434 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)