### PR TITLE
Remove global logger config

### DIFF
--- a/distfit/distfit.py
+++ b/distfit/distfit.py
@@ -21,7 +21,7 @@ import logging
 import colourmap
 
 import warnings
-warnings.filterwarnings('ignore')
+
 logger = logging.getLogger(__name__)
 
 # %% Class dist
@@ -2213,6 +2213,7 @@ def _compute_score_distribution(data, X, y_obs, DISTRIBUTIONS, stats, cmap='Set1
             # Fit the distribution. However, this can result in an error. I need the try-except.
             # Ignore warnings from data that can't be fit
             with warnings.catch_warnings():
+                warnings.filterwarnings("ignore")
                 # fit dist to data
                 params = distribution.fit(data)
                 logger.debug(params)

--- a/distfit/distfit.py
+++ b/distfit/distfit.py
@@ -23,8 +23,6 @@ import colourmap
 import warnings
 warnings.filterwarnings('ignore')
 logger = logging.getLogger(__name__)
-if not logger.hasHandlers():
-    logging.basicConfig(level=logging.INFO, format='[{asctime}] [{name}] [{levelname}] {message}', style='{', datefmt='%d-%m-%Y %H:%M:%S')
 
 # %% Class dist
 class distfit:

--- a/distfit/distfit.py
+++ b/distfit/distfit.py
@@ -2243,6 +2243,7 @@ def _compute_score_distribution(data, X, y_obs, DISTRIBUTIONS, stats, cmap='Set1
                 return (i, distr_name, score, loc, scale, arg, params, distribution_fit, bootstrap_score, bootstrap_pass, start_time)
 
         except Exception as e:
+            logger.info("Failed to fit distribution '{}': {}", distribution, e, exc_info=e)
             return None
 
     # Parallelize the loop over distributions

--- a/distfit/distfit.py
+++ b/distfit/distfit.py
@@ -2243,7 +2243,7 @@ def _compute_score_distribution(data, X, y_obs, DISTRIBUTIONS, stats, cmap='Set1
                 return (i, distr_name, score, loc, scale, arg, params, distribution_fit, bootstrap_score, bootstrap_pass, start_time)
 
         except Exception as e:
-            logger.info("Failed to fit distribution '{}': {}", distribution, e, exc_info=e)
+            logger.info("Failed to fit distribution '%s': %s", distribution, e, exc_info=e)
             return None
 
     # Parallelize the loop over distributions


### PR DESCRIPTION
This PR removes the global logger configuration in the `distfit.distfit` module. This change allows the user of `distfit` to choose how the global logger shall be configured.
In order for this change to take effect, I had to locally remove the global logger configuration in `colourmap` as well. That change must be done in the `colourmap` repo.

It also moves the global `warnings.filterwarning()` to the local context region inside `fit_distribution()` such that the warning filter does not spill over to other modules.

It does not touch the additional logging infrastructure that is defined in the `distfit` module (`__init__.py`). It is a but unfortunate that this module instantiate a new `StreamHandler()` and attaches it to the local `distfit` logger. But this logic does at least not modify the global logger. I can have a stab on cleaning up that logic as well, if you want to.